### PR TITLE
Fix clone boards not booting, DVI monitors not showing image and RP2040 red flicker regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
-
+Fix for crashing RP2040 clone boards on boot. Regression fix for heavy screenflicker op RP2040 in some games.
 Beta **NES Zapper** (light gun) support on the custom PCB, a **Recently played** list of the last 20 games, no more reflashing a game that is already in flash on boards without PSRAM, and correct A/B buttons for **SNES controllers wired to a NES port**.
 
 
@@ -25,7 +25,7 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 
 ## Display
 
-- **DVI mode sends a real DVI signal again.** Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright — no picture at all on those displays ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged.
+- **DVI mode sends a real DVI signal again.** Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright — no picture at all on those displays ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged. Thanks to [javavi](https://github.com/javavi) for testing. 
 - Some displays lose sync on a plain DVI signal — that is why v0.43 changed it. If yours does, use **HDMI** mode.
 
 ## Fixes
@@ -33,6 +33,7 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 - **RP2040: red flicker and a frame rate flipping between 60 and 30 are gone.** Two feature tests added in v0.41 sat on the 6502 core's hottest paths and cost ~3.5% of the frame budget — enough for heavier games such as *Prince of Persia* to miss the DVI scanline deadline, which paints the line red. NSF playback is unaffected.
 - A `.nes` file claiming **mapper 31** reports "unsupported" again instead of booting into the NSF player.
 - A flag test in `K6502_Read`'s ROM branch or `step()`'s loop costs 1-2% of the RP2040 frame budget. Keep feature dispatch out of both.
+- RP2040 Clone boards no longer crash upon booting the emulator.[#214](https://github.com/fhoedemakers/pico-infonesPlus/issues/214). Thanks to [chubunov](https://github.com/chubunov) for testing.
 
 # v0.46
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,6 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 
 - **RP2040: red flicker and a frame rate flipping between 60 and 30 are gone.** Two feature tests added in v0.41 sat on the 6502 core's hottest paths and cost ~3.5% of the frame budget — enough for heavier games such as *Prince of Persia* to miss the DVI scanline deadline, which paints the line red. NSF playback is unaffected.
 - A `.nes` file claiming **mapper 31** reports "unsupported" again instead of booting into the NSF player.
-
-## Developer
-
-- New `PICO_HDMI_DVI_USE_DATA_ISLANDS` in pico_shared's HDMI driver, default `0` (DVI 1.0). Set to `1` for the v0.43 signal. Only the `dvi_mode` branches are affected.
 - A flag test in `K6502_Read`'s ROM branch or `step()`'s loop costs 1-2% of the RP2040 frame budget. Keep feature dispatch out of both.
 
 # v0.46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Two things to keep in mind: `FLASH_QE_SET_1.uf2` must not be applied twice (reco
 
 See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/pico-infonesPlus#psram-with-a-non-winbond-flash-chip) in the readme.
 
+# v0.47
+
+## Display
+
+- **DVI mode sends a real DVI signal again.** Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright — no picture at all on those displays ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged.
+- Some displays lose sync on a plain DVI signal — that is why v0.43 changed it. If yours does, use **HDMI** mode.
+
+## Developer
+
+- New `PICO_HDMI_DVI_USE_DATA_ISLANDS` in pico_shared's HDMI driver, default `0` (DVI 1.0). Set to `1` for the v0.43 signal. Only the `dvi_mode` branches are affected.
+
 # v0.46
 
 ## Menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,15 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 - **DVI mode sends a real DVI signal again.** Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright — no picture at all on those displays ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged.
 - Some displays lose sync on a plain DVI signal — that is why v0.43 changed it. If yours does, use **HDMI** mode.
 
+## Fixes
+
+- **RP2040: red flicker and a frame rate flipping between 60 and 30 are gone.** Two feature tests added in v0.41 sat on the 6502 core's hottest paths and cost ~3.5% of the frame budget — enough for heavier games such as *Prince of Persia* to miss the DVI scanline deadline, which paints the line red. NSF playback is unaffected.
+- A `.nes` file claiming **mapper 31** reports "unsupported" again instead of booting into the NSF player.
+
 ## Developer
 
 - New `PICO_HDMI_DVI_USE_DATA_ISLANDS` in pico_shared's HDMI driver, default `0` (DVI 1.0). Set to `1` for the v0.43 signal. Only the `dvi_mode` branches are affected.
+- A flag test in `K6502_Read`'s ROM branch or `step()`'s loop costs 1-2% of the RP2040 frame budget. Keep feature dispatch out of both.
 
 # v0.46
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 - A flag test in `K6502_Read`'s ROM branch or `step()`'s loop costs 1-2% of the RP2040 frame budget. Keep feature dispatch out of both.
 - RP2040 Clone boards no longer crash upon booting the emulator.[#214](https://github.com/fhoedemakers/pico-infonesPlus/issues/214). Thanks to [chubunov](https://github.com/chubunov) for testing.
 
+## Other
+- On HSTX boards, the framerate overlay now also shows a resync counter (`R<n>`) — the number of times the watchdog has had to resync the display since boot. A steadily rising count points to a display that is struggling to hold sync.
+
 # v0.46
 
 ## Menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
-Fix for crashing RP2040 clone boards on boot. Regression fix for heavy screenflicker op RP2040 in some games. Fix for no image on DVI monitors
+Fix for crashing RP2040 clone boards on boot. Regression fix for heavy screenflicker on RP2040 in some games. Fix for no image on DVI monitors
 Beta **NES Zapper** (light gun) support on the custom PCB, a **Recently played** list of the last 20 games, no more reflashing a game that is already in flash on boards without PSRAM, and correct A/B buttons for **SNES controllers wired to a NES port**.
 
 
@@ -25,15 +25,15 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 
 ## Display
 
-- **DVI mode sends a real DVI signal again.** Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright — no picture at all on those displays ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged. Thanks to [javavi](https://github.com/javavi) for testing. 
-- Some displays lose sync on a plain DVI signal — that is why v0.43 changed it. If yours does, use **HDMI** mode.
+- Fix regression introduced in v0.43 that caused DVI monitors to no longer show an image. Since v0.43 the **DVI** setting sent an HDMI signal without audio, which monitors with a DVI input reject outright ([#217](https://github.com/fhoedemakers/pico-infonesPlus/issues/217)). v0.42 was the last working version. HDMI mode is unchanged. Thanks to [javavi](https://github.com/javavi) for testing.
 
 ## Fixes
 
-- **RP2040: red flicker and a frame rate flipping between 60 and 30 are gone.** Two feature tests added in v0.41 sat on the 6502 core's hottest paths and cost ~3.5% of the frame budget — enough for heavier games such as *Prince of Persia* to miss the DVI scanline deadline, which paints the line red. NSF playback is unaffected.
-- A `.nes` file claiming **mapper 31** reports "unsupported" again instead of booting into the NSF player.
-- A flag test in `K6502_Read`'s ROM branch or `step()`'s loop costs 1-2% of the RP2040 frame budget. Keep feature dispatch out of both.
 - RP2040 Clone boards no longer crash upon booting the emulator.[#214](https://github.com/fhoedemakers/pico-infonesPlus/issues/214). Thanks to [chubunov](https://github.com/chubunov) for testing.
+- Fixed a regression from v0.41 that made some games on RP2040 boards flicker red and drop from 60 to 30 fps. Two extra checks added in v0.41 slowed down the emulator core just enough for demanding games like *Prince of Persia* to fall behind. NSF playback was never affected.
+- Other RP2040 performance fixes.
+- A `.nes` file claiming **mapper 31** reports "unsupported" again instead of booting into the NSF player.
+
 
 ## Other
 - On HSTX boards, the framerate overlay now also shows a resync counter (`R<n>`) — the number of times the watchdog has had to resync the display since boot. A steadily rising count points to a display that is struggling to hold sync.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
-Fix for crashing RP2040 clone boards on boot. Regression fix for heavy screenflicker op RP2040 in some games.
+Fix for crashing RP2040 clone boards on boot. Regression fix for heavy screenflicker op RP2040 in some games. Fix for no image on DVI monitors
 Beta **NES Zapper** (light gun) support on the custom PCB, a **Recently played** list of the last 20 games, no more reflashing a game that is already in flash on boards without PSRAM, and correct A/B buttons for **SNES controllers wired to a NES port**.
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 # Hardware / board selection (project-specific)
 # ---------------------------------------------------------------------------
 if(NOT HW_CONFIG)
-    set(HW_CONFIG 2 CACHE STRING "Select the hardware configuration for your board")
+    set(HW_CONFIG 1 CACHE STRING "Select the hardware configuration for your board")
 endif()
 
 if(NOT USE_HSTX)

--- a/infones/InfoNES.cpp
+++ b/infones/InfoNES.cpp
@@ -544,6 +544,17 @@ int InfoNES_Reset()
   MapperBlobSize = nullptr;
   MapperSaveBlob = nullptr;
   MapperLoadBlob = nullptr;
+  // Mapper 31 in MapperTable is the synthetic NSF dispatch set up by the
+  // IsNSF branch above, not the real NSF-compilation multicart mapper. A
+  // .nes file whose header claims mapper 31 must still be reported as
+  // unsupported rather than booting into the NSF player with an
+  // uninitialised NsfHeader.
+  if (MapperNo == 31 && !IsNSF)
+  {
+    InfoNES_Error("Mapper #%d is unsupported.", MapperNo);
+    return -1;
+  }
+
   // Get Mapper Table Index
   for (nIdx = 0; MapperTable[nIdx].nMapperNo != -1; ++nIdx)
   {

--- a/infones/InfoNES.h
+++ b/infones/InfoNES.h
@@ -306,7 +306,9 @@ extern BYTE ROM_Trainer;
 extern BYTE ROM_FourScr;
 
 /* True when the loaded image is a Famicom Disk System disk (no iNES header).
-   Set by parseROM in main before InfoNES_Reset. RP2350 + PSRAM only. */
+   Set by parseROM in main before InfoNES_Reset. RP2350 only - FDS is
+   compiled out on RP2040, so this is always false there. PSRAM is not
+   required; it only selects multi-side over single-side drive mode. */
 extern bool IsFDS;
 
 /* True when the loaded image is an NSF (Nintendo Sound Format) file. */

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -2,10 +2,13 @@
 /*                                                                   */
 /*  InfoNES_FDS.cpp : Famicom Disk System support                    */
 /*                                                                   */
-/*  Phase 1: detection, preflight gate (RP2350 + PSRAM + BIOS file + */
-/*  memory), buffer allocation, BIOS load. Mapper 20 init, drive     */
-/*  emulation, disk swap UI, save-data flush, audio and save-states  */
-/*  are added in later phases.                                       */
+/*  Detection and preflight gate (BIOS file + memory), buffer        */
+/*  allocation, BIOS load, Mapper 20 init, drive emulation, disk     */
+/*  swap UI, save-data sidecar, audio and save-states.               */
+/*                                                                   */
+/*  RP2350 only - main.cpp calls fdsParse() under #if PICO_RP2350.   */
+/*  PSRAM is not required: without it the drive runs in single-side  */
+/*  mode (fds_single_side_mode), rebuilding one side at a time.      */
 /*                                                                   */
 /*===================================================================*/
 

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -15,6 +15,7 @@
 #include "FrensHelpers.h"
 #include <cstring>
 #include <cstdio>
+#include <pico.h>   /* PICO_RP2350 - the RP2040 bank window below depends on it */
 
 #ifndef __not_in_flash_func
 #define __not_in_flash_func(name) name
@@ -88,6 +89,30 @@ static BYTE *NsfShadowLead = nullptr;
 static BYTE *NsfShadowTail = nullptr;
 static int NsfShadowLeadPage = -1;
 static int NsfShadowTailPage = -1;
+
+#if !PICO_RP2350
+/* RP2040 only: a contiguous 32KB SRAM image of $8000-$FFFF that
+   ROMBANK0..3 point at, so K6502_Read needs no `if (IsNSF)` test on its
+   hot ROM path (see the long comment in K6502_rw.h - that test was the
+   v0.41 RP2040 frame-rate regression). Bank writes copy the 4KB page in
+   rather than just repointing; NSF mode skips the whole PPU pixel
+   pipeline, so it has the budget the NES path does not. NsfWindowPage
+   suppresses the copy when a register is rewritten with the value it
+   already holds, which is the common case. */
+static BYTE *NsfWindow = nullptr;
+static int NsfWindowPage[8] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+
+/* $FFFC-$FFFF live in bank register 7; rewrite them after every copy
+   that lands there. On RP2350 K6502_Read serves these directly. */
+static void NsfPatchVectors()
+{
+    if (!NsfWindow) return;
+    NsfWindow[0x7FFC] = 0x00;
+    NsfWindow[0x7FFD] = 0x41;  /* reset -> $4100 */
+    NsfWindow[0x7FFE] = 0x10;
+    NsfWindow[0x7FFF] = 0x41;  /* IRQ   -> $4110 */
+}
+#endif
 
 /* Build a 4KB shadow page that includes any required zero padding. */
 static void NsfBuildShadowPage(BYTE *dst, int page)
@@ -166,6 +191,19 @@ static void MapNsf_RenderScreen(BYTE byMode);
 static void __not_in_flash_func(NsfApplyBank)(int reg)
 {
     int page = NsfBankRegs[reg];
+#if !PICO_RP2350
+    if (!NsfWindow) return;
+    if (NsfWindowPage[reg] == page) return;
+    NsfWindowPage[reg] = page;
+    BYTE *dst = NsfWindow + reg * 0x1000;
+    if (page >= NsfPageCount)
+        memset(dst, 0, 0x1000);
+    else
+        NsfBuildShadowPage(dst, page);
+    if (reg == 7)
+        NsfPatchVectors();
+    return;
+#else
     if (page >= NsfPageCount)
     {
         NsfBank4K[reg] = NsfShadowZero;
@@ -184,6 +222,7 @@ static void __not_in_flash_func(NsfApplyBank)(int reg)
            Read directly from flash, no copy. */
         NsfBank4K[reg] = (BYTE *)(NsfRomData + page * 0x1000 - NsfLoadOffset);
     }
+#endif
 }
 
 /* Allocate (once) and rebuild the partial-page shadow buffers. Called
@@ -191,6 +230,14 @@ static void __not_in_flash_func(NsfApplyBank)(int reg)
    from a previous NSF in the same boot doesn't carry over. */
 static void NsfBuildShadows()
 {
+#if !PICO_RP2350
+    /* RP2040 uses the contiguous 32KB window instead of per-page shadow
+       buffers; force every register to re-copy for the new NSF. */
+    if (!NsfWindow) NsfWindow = (BYTE *)Frens::f_malloc(0x8000);
+    for (int i = 0; i < 8; i++)
+        NsfWindowPage[i] = -1;
+    return;
+#else
     if (!NsfShadowZero) NsfShadowZero = (BYTE *)Frens::f_malloc(0x1000);
     if (!NsfShadowLead) NsfShadowLead = (BYTE *)Frens::f_malloc(0x1000);
     if (!NsfShadowTail) NsfShadowTail = (BYTE *)Frens::f_malloc(0x1000);
@@ -223,6 +270,7 @@ static void NsfBuildShadows()
             NsfBuildShadowPage(NsfShadowTail, lastPage);
         }
     }
+#endif
 }
 
 /* Initial bank apply for all 8 registers. K6502 vectors at $FFFC-$FFFF
@@ -234,6 +282,17 @@ static void NsfApplyAllBanks()
     for (int i = 0; i < 8; i++)
         NsfApplyBank(i);
 
+#if !PICO_RP2350
+    /* RP2040: ROMBANK[] *is* the NSF read path - K6502_Read has no NSF
+       special case there. Fall back to ChrBuf if the 32KB window could
+       not be allocated, so stray reads still land in mapped memory. */
+    BYTE *base = NsfWindow ? NsfWindow : ChrBuf;
+    ROMBANK0 = base + 0x0000;
+    ROMBANK1 = base + 0x2000;
+    ROMBANK2 = base + 0x4000;
+    ROMBANK3 = base + 0x6000;
+    NsfPatchVectors();
+#else
     /* ROMBANK[] is unused in NSF mode (K6502_Read goes via NsfBank4K),
        but point it at ChrBuf anyway so any stray access from sprite-DMA
        paths or leftover mapper code lands in addressable memory rather
@@ -242,6 +301,7 @@ static void NsfApplyAllBanks()
     ROMBANK1 = ChrBuf + 0x2000;
     ROMBANK2 = ChrBuf + 0x4000;
     ROMBANK3 = ChrBuf + 0x6000;
+#endif
 }
 
 /*===================================================================*/
@@ -351,6 +411,12 @@ void nsfRelease()
     if (NsfShadowTail) { Frens::f_free(NsfShadowTail); NsfShadowTail = nullptr; }
     NsfShadowLeadPage = -1;
     NsfShadowTailPage = -1;
+
+#if !PICO_RP2350
+    if (NsfWindow) { Frens::f_free(NsfWindow); NsfWindow = nullptr; }
+    for (int i = 0; i < 8; i++)
+        NsfWindowPage[i] = -1;
+#endif
 
     /* Drop the bank pointers — NsfBank4K entries point into freed
        buffers or into NsfRomData (which is becoming invalid). */

--- a/infones/K6502.cpp
+++ b/infones/K6502.cpp
@@ -511,11 +511,19 @@ static void __not_in_flash_func(step)(int wClocks)
     // }
 
     /* Mesen2-style FDS auto-disk-insert: intercept BIOS $E445 (disk
-       verification routine) to auto-switch to the correct side. */
+       verification routine) to auto-switch to the correct side.
+       RP2350 only: FDS support is compiled out on RP2040, so main.cpp
+       never calls fdsParse() there and IsFDS can never become true. On
+       RP2040 this test cost ~6 cycles on *every* emulated instruction
+       (~0.19ms per frame at 252MHz), which was enough to push heavy
+       games past the DVI line deadline - see the red-flicker note in
+       K6502_rw.h. */
+#if PICO_RP2350
     if (IsFDS && PC == 0xE445)
     {
       fdsAutoInsertCheck();
     }
+#endif
 
     // Read an instruction
     byCode = K6502_Read(PC++);

--- a/infones/K6502_rw.h
+++ b/infones/K6502_rw.h
@@ -78,6 +78,26 @@ static inline BYTE __not_in_flash_func(K6502_Read)(WORD wAddr)
 
   if (wAddr >= 0x8000)
   {
+    /* This is the single hottest branch in the emulator: every opcode
+       fetch and most operand fetches land here. Anything added to it is
+       paid ~2x per emulated instruction, i.e. ~16000 times per frame.
+       On RP2040 the `if (IsNSF)` test below cost ~5 cycles a read
+       (~0.3ms per frame at 252MHz), and the code it added spread the
+       opcode dispatch in step() past the +-254 byte reach of a Thumb
+       conditional branch, so every `beq.n target` in the dispatch chain
+       became a `bne.n .+4; b.n target` pair on top of that. Together
+       with the FDS $E445 trap in K6502.cpp that came to roughly 0.6ms
+       of the 16.67ms frame budget - enough to make core0 miss the DVI
+       line deadline on heavy games, at which
+       point dvi::DMA::update() paints the scanline from listActiveError_
+       (solid red) and the frame rate halves to 30. That was the
+       Prince of Persia red flicker reported against v0.41.
+
+       So NSF gets its own read path only on RP2350, where there is
+       headroom. On RP2040, NSF mode materialises its 4KB banks into a
+       32KB SRAM window that ROMBANK0..3 point at (see NsfApplyBank in
+       InfoNES_NSF.cpp), which keeps this branch free of any NSF test. */
+#if PICO_RP2350
     if (IsNSF)
     {
       /* NSF reset/IRQ vectors are hardcoded so NsfBank4K can point
@@ -95,6 +115,7 @@ static inline BYTE __not_in_flash_func(K6502_Read)(WORD wAddr)
       }
       return NsfBank4K[(wAddr - 0x8000) >> 12][wAddr & 0xFFF];
     }
+#endif
     return ROMBANK[(wAddr - 0x8000) >> 13][wAddr & 0x1fff];
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1528,6 +1528,17 @@ int main()
 #if HSTX
     printf("HSTX freq: %d\n", clock_get_hz(clk_hstx) / 1000);
 #endif
+    {
+        // Which flash part is fitted decides how far the board can be overclocked,
+        // so log it: genuine Picos carry a 133 MHz Winbond, clones often a 104 MHz
+        // part that cannot keep up with clk_sys/2 at emulator speeds.
+        uint32_t jedec = Frens::storage_get_flash_jedec_id();
+        printf("Flash chip: JEDEC %06x (%s), %d MB\n",
+               jedec,
+               Frens::storage_get_flash_manufacturer_name((jedec >> 16) & 0xff),
+               (1 << (jedec & 0xff)) / (1024 * 1024));
+        printf("Flash freq: %d kHz\n", Frens::getFlashClockHz() / 1000);
+    }
     printf("Stack size: %d bytes\n", PICO_STACK_SIZE);
     printf("==========================================================================================\n");
     printf("Starting up...\n");

--- a/main.cpp
+++ b/main.cpp
@@ -1368,7 +1368,27 @@ void __not_in_flash_func(InfoNES_PostDrawLine)(int line)
     // Display frame rate
     if (settings.flags.displayFrameRate && line >= 8 && line < 16)
     {
-        char fpsString[2];
+        char fpsString[16];
+        int nchars = 0;
+        fpsString[nchars++] = '0' + (fps / 10);
+        fpsString[nchars++] = '0' + (fps % 10);
+#if HSTX
+        // Append the HSTX auto-resync count so display glitches are visible.
+        fpsString[nchars++] = ' ';
+        fpsString[nchars++] = 'R';
+        int resync = get_video_output_resync_count();
+        char digits[10];
+        int nd = 0;
+        do
+        {
+            digits[nd++] = '0' + (resync % 10);
+            resync /= 10;
+        } while (resync > 0 && nd < (int)sizeof(digits));
+        while (nd > 0 && nchars < (int)sizeof(fpsString))
+        {
+            fpsString[nchars++] = digits[--nd];
+        }
+#endif
         WORD *fpsBuffer =
 #if !HSTX
             currentLineBuf == nullptr ? currentLineBuffer_->data() + 40 : currentLineBuf + 40;
@@ -1377,14 +1397,11 @@ void __not_in_flash_func(InfoNES_PostDrawLine)(int line)
 #endif
         WORD fgc = NesPalette[48];
         WORD bgc = NesPalette[15];
-        fpsString[0] = '0' + (fps / 10);
-        fpsString[1] = '0' + (fps % 10);
 
         int rowInChar = line % 8;
-        for (auto i = 0; i < 2; i++)
+        for (auto i = 0; i < nchars; i++)
         {
-            char firstFpsDigit = fpsString[i];
-            char fontSlice = getcharslicefrom8x8font(firstFpsDigit, rowInChar);
+            char fontSlice = getcharslicefrom8x8font(fpsString[i], rowInChar);
             for (auto bit = 0; bit < 8; bit++)
             {
                 if (fontSlice & 1)


### PR DESCRIPTION
Closes #214 
CLoses #217 

This pull request focuses on improving compatibility and performance for RP2040-based boards, especially addressing regressions affecting display output and emulator speed. It also introduces targeted optimizations for NSF (Nintendo Sound Format) playback, fixes mapper detection, and enhances debugging information for hardware variants. The most important changes are grouped below.

**RP2040 Bug Fixes and Performance Improvements:**

- Fixed a regression that caused heavy screen flicker and frame rate drops (from 60 to 30 fps) on RP2040 boards in demanding games by removing costly checks from hot code paths and optimizing NSF handling. This resolves the "red flicker" issue reported for v0.41. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R40) [[2]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R93-R116) [[3]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R194-R206) [[4]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R225-R240) [[5]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R273) [[6]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R285-R295) [[7]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R304) [[8]](diffhunk://#diff-39d651bc45e8aa169950fa94447a21b639bcdd63f864ee7a1e8f5705e3035ed0R415-R420) [[9]](diffhunk://#diff-f66f7af5f36fbc5b1920cf10d8ed871618ac01982ae1e5fcdc24a494ceb5e19aR81-R100) [[10]](diffhunk://#diff-f66f7af5f36fbc5b1920cf10d8ed871618ac01982ae1e5fcdc24a494ceb5e19aR118) [[11]](diffhunk://#diff-e5fdfad4d1c236b9ce24b06731d5989a326229d07fd55714011bf6c60cc848c2L514-R526)
- Fixed a boot crash affecting RP2040 clone boards.

**Display and Compatibility Fixes:**

- Restored DVI monitor compatibility by correcting the DVI mode to send a proper DVI signal instead of HDMI-without-audio, fixing the regression introduced in v0.43.
- Added a resync counter to the framerate overlay on HSTX boards to help diagnose display sync issues. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL1371-R1391) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL1380-R1404) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R40)

**Mapper and File Handling:**

- `.nes` files claiming mapper 31 are now correctly reported as unsupported, instead of erroneously booting into the NSF player. [[1]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R547-R557) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R40)

**Hardware and Build Defaults:**

- Changed the default hardware configuration (`HW_CONFIG`) from 2 to 1 in `CMakeLists.txt`, making board selection more predictable for new builds.
- Improved hardware diagnostics on startup by logging flash chip JEDEC ID, manufacturer, and maximum supported clock speed.

**Documentation and Maintenance:**

- Updated `CHANGELOG.md` with detailed notes on the fixes and improvements, including credits and links to relevant issues. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL2-R2) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R40)
- Clarified FDS (Famicom Disk System) support documentation and code comments to reflect platform-specific builds and requirements. [[1]](diffhunk://#diff-331279f0500a0df125421502aadfbed93de6bcf5d97004681cb1165c7adf3579L309-R311) [[2]](diffhunk://#diff-97ad0187fc5ba21c6fc8e5b6a4f4be9cb51c21394869ca784237d2ce7ff2b3beL5-R11)

**Submodule Update:**

- Updated the `pico_shared` submodule to the latest commit.