### PR TITLE
Fix NES vertical framing on HSTX

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1338,7 +1338,7 @@ void __not_in_flash_func(InfoNES_PreDrawLine)(int line)
     //    (*b)[319] = line + dvi_->getFrameCounter();
 
 #else
-    currentLineBuffer_ = hstx_getlineFromFramebuffer(line + 4); // Top Margin of 4 lines
+    currentLineBuffer_ = hstx_getlineFromFramebuffer(line);
     InfoNES_SetLineBuffer(currentLineBuffer_ + 32, 640);
 
 #endif


### PR DESCRIPTION
## Summary

- Remove the extra four-line offset from the HSTX framebuffer path.
- Keep the NES image vertically centered with symmetric overscan margins.

## Problem

InfoNES already skips the first and last four source scanlines. The HSTX framebuffer path added another four-line offset, which produced a larger margin at the top and no margin at the bottom.

## Fix

Use the source scanline index directly when selecting the HSTX framebuffer line.

## Testing

- Built the Release configuration for RP2350 with `HW_CONFIG=2` and HSTX enabled.
- Verified that the PR contains one source file change with one insertion and one deletion.