### PR TITLE
USB drive mode: show the SD card on a PC over USB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "pico_lib"]
 	path = pico_lib
-	url = https://github.com/fhoedemakers/pico_lib.git
+	url = https://github.com/PicoPlus-devel/pico_lib.git
 [submodule "tusb_xinput"]
 	path = tusb_xinput
-	url = https://github.com/fhoedemakers/tusb_xinput.git
+	url = https://github.com/PicoPlus-devel/tusb_xinput.git
 [submodule "pico_shared"]
 	path = pico_shared
-	url = https://github.com/fhoedemakers/pico_shared.git
+	url = https://github.com/PicoPlus-devel/pico_shared.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-Fix for a flickering band of wrong graphics in scrolling games such as *Final Fantasy* and *Zelda II*, and for the picture sitting too low on HSTX boards.
+New USB drive mode: show the SD card on your computer over USB straight from the settings menu (RP2350 boards). Plus a fix for a flickering band of wrong graphics in scrolling games such as *Final Fantasy* and *Zelda II*, and for the picture sitting too low on HSTX boards.
 
 
 # General Info
@@ -22,6 +22,10 @@ Two things to keep in mind: `FLASH_QE_SET_1.uf2` must not be applied twice (reco
 See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/pico-infonesPlus#psram-with-a-non-winbond-flash-chip) in the readme.
 
 # v0.48
+
+## New
+
+- **USB drive mode**: the settings menu can now show the SD card on your computer over USB, so you can add or remove games without taking the card out. Open the menu with SELECT from the game list, pick *USB drive mode*, then eject the drive on your computer when you are done. RP2350 boards only, and not available while a game is running. On boards that use the built-in USB port for controllers, the console restarts when you leave USB drive mode.
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-New USB drive mode: show the SD card on your computer over USB straight from the settings menu (RP2350 boards). Plus a fix for a flickering band of wrong graphics in scrolling games such as *Final Fantasy* and *Zelda II*, and for the picture sitting too low on HSTX boards.
+New USB drive mode: show the SD card on your computer over USB straight from the settings menu. Plus a fix for a flickering band of wrong graphics in scrolling games such as *Final Fantasy* and *Zelda II*, and for the picture sitting too low on HSTX boards.
 
 
 # General Info
@@ -25,7 +25,8 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 
 ## New
 
-- **USB drive mode**: the settings menu can now show the SD card on your computer over USB, so you can add or remove games without taking the card out. Open the menu with SELECT from the game list, pick *USB drive mode*, then eject the drive on your computer when you are done. RP2350 boards only, and not available while a game is running. On boards that use the built-in USB port for controllers, the console restarts when you leave USB drive mode.
+- **USB drive mode**: the settings menu can now show the SD card on your computer over USB, so you can add or remove games without taking the card out. Open the menu with SELECT from the game list, pick *USB drive mode*, then eject the drive on your computer or press B when you are done. It is not available while a game is running.
+- On boards where controllers plug into the console's own USB port, that same port is the one you connect to the computer, so a USB controller cannot be used in this mode: press B on a controller in the NES port, or eject from the computer. The console restarts afterwards. On RP2040 boards the screen also goes black while the card is mounted; the menu explains this first and lets you back out.
 
 ## Fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 # Hardware / board selection (project-specific)
 # ---------------------------------------------------------------------------
 if(NOT HW_CONFIG)
-    set(HW_CONFIG 1 CACHE STRING "Select the hardware configuration for your board")
+    set(HW_CONFIG 8 CACHE STRING "Select the hardware configuration for your board")
 endif()
 
 if(NOT USE_HSTX)
@@ -124,7 +124,7 @@ else()
 endif()
 
 if(NOT PICO_BOARD)
-    set(PICO_BOARD pico CACHE STRING "Board type")
+    set(PICO_BOARD pico2 CACHE STRING "Board type")
     message("PICO_BOARD not set, using default: ${PICO_BOARD}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,24 @@ target_compile_definitions(${projectname} PRIVATE
     #HSTX_DEBUG=1
 )
 
+# ---------------------------------------------------------------------------
+# USB drive mode: the "USB drive mode" entry in the settings menu shows the SD
+# card on a PC as a mass storage device. RP2350 only. The device stack is
+# started when that screen opens and stopped when it closes, so nothing outside
+# it changes; when this is 0 no tinyusb device code is linked at all.
+# ---------------------------------------------------------------------------
+option(ENABLE_USB_MSC "Show the SD card on a PC over USB from the settings menu" ON)
+if(ENABLE_USB_MSC AND NOT PICO_PLATFORM STREQUAL "rp2040")
+    set(USB_MSC_ENABLED 1)
+else()
+    set(USB_MSC_ENABLED 0)
+endif()
+message(STATUS "USB drive mode (mass storage): ${USB_MSC_ENABLED}")
+target_compile_definitions(${projectname} PRIVATE FRENS_USB_MSC=${USB_MSC_ENABLED})
+if(USB_MSC_ENABLED)
+    target_link_libraries(${projectname} PRIVATE tinyusb_device pico_unique_id)
+endif()
+
 if(NOT PICO_PLATFORM STREQUAL "rp2040")
     message(STATUS "Using PICO_PIO_USE_GPIO_BASE=1 for non-rp2040 platforms.")
     target_compile_definitions(${projectname} PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 # Hardware / board selection (project-specific)
 # ---------------------------------------------------------------------------
 if(NOT HW_CONFIG)
-    set(HW_CONFIG 8 CACHE STRING "Select the hardware configuration for your board")
+    set(HW_CONFIG 2 CACHE STRING "Select the hardware configuration for your board")
 endif()
 
 if(NOT USE_HSTX)
@@ -293,12 +293,16 @@ target_compile_definitions(${projectname} PRIVATE
 
 # ---------------------------------------------------------------------------
 # USB drive mode: the "USB drive mode" entry in the settings menu shows the SD
-# card on a PC as a mass storage device. RP2350 only. The device stack is
-# started when that screen opens and stopped when it closes, so nothing outside
-# it changes; when this is 0 no tinyusb device code is linked at all.
+# card on a PC as a mass storage device. The device stack is started when that
+# screen opens and stopped when it closes, so nothing outside it changes; when
+# this is 0 no tinyusb device code is linked at all.
+#
+# RP2040 included: those boards take the no-PIO-USB route, so the USB host has
+# to give the native port back - gamepads stop while the card is mounted and the
+# console reboots on the way out.
 # ---------------------------------------------------------------------------
 option(ENABLE_USB_MSC "Show the SD card on a PC over USB from the settings menu" ON)
-if(ENABLE_USB_MSC AND NOT PICO_PLATFORM STREQUAL "rp2040")
+if(ENABLE_USB_MSC)
     set(USB_MSC_ENABLED 1)
 else()
     set(USB_MSC_ENABLED 0)
@@ -307,6 +311,26 @@ message(STATUS "USB drive mode (mass storage): ${USB_MSC_ENABLED}")
 target_compile_definitions(${projectname} PRIVATE FRENS_USB_MSC=${USB_MSC_ENABLED})
 if(USB_MSC_ENABLED)
     target_link_libraries(${projectname} PRIVATE tinyusb_device pico_unique_id)
+    # Widen the pool of claimable hardware spinlocks from 8 to 12.
+    #
+    # spin_lock_claim_unused() only hands out PICO_SPINLOCK_ID_CLAIM_FREE_FIRST
+    # ..LAST, which is ids 24..31 by default - eight in total. On PicoDVI builds
+    # dvi::DVI alone takes four of them (validTMDSQueue_, freeTMDSQueue_,
+    # validLineQueue_, freeLineQueue_ - util::Queue holds a util::SpinLock), and
+    # the TinyUSB host stack takes most of the rest, so bringing the device
+    # stack up for USB drive mode ran the pool dry and panicked with "No
+    # spinlocks are available" on the very first visit. HSTX builds have no
+    # PicoDVI and so never hit it.
+    #
+    # The striped range gives up the four ids instead. Striped locks are handed
+    # out round-robin and are shared by design, so a smaller range costs a
+    # little more contention and nothing else.
+    target_compile_definitions(${projectname} PRIVATE
+        PICO_SPINLOCK_ID_STRIPED_FIRST=16
+        PICO_SPINLOCK_ID_STRIPED_LAST=19
+        PICO_SPINLOCK_ID_CLAIM_FREE_FIRST=20
+        PICO_SPINLOCK_ID_CLAIM_FREE_LAST=31
+    )
 endif()
 
 if(NOT PICO_PLATFORM STREQUAL "rp2040")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **NES Emulation** – Execute NES ROM files directly from an SD card
 - **SD Card Menu System** – Browse and launch games from an on-screen menu interface
 - **Recently Played List** – The last 20 games you started, one button press away in the menu ([details](#recently-played-games))
+- **USB Drive Mode** – Present the SD card to a computer as a USB drive from the settings menu, so games can be added or removed without taking the card out ([details](#usb-drive-mode))
 - **Dual Controller Support** – Two simultaneous controllers for multiplayer gameplay ([details](#about-two-player-games))
 - **NES Zapper (light gun)** – Beta support in controller port 2 of the [custom PCB](#nes-zapper-light-gun), using LCD-lag-corrected ROM patches and a third-party gun such as the Tomee Zapp Gun
 - **Save State Management** – Automatic battery-backed SRAM persistence and manual save states
@@ -1121,8 +1122,9 @@ running. Not every entry is available on every board or in every situation.
 | FDS Auto Swap Disk side | Swap the disk side automatically when the game asks for it. Off by default. FDS games only. |
 | FDS Auto Insert Disk 1 On Start | Insert disk 1 automatically at start. On by default. FDS games only. |
 | Overclock | Raise the CPU clock from 252 MHz to 378 MHz. Only on HSTX boards with PSRAM, and currently only needed for *Lagrange Point (JP)*. Menu only, not available in-game. |
-| Enter BOOTSEL Mode | Reboot into BOOTSEL so you can flash new firmware. |
 | Controller Test | Show a gamepad graphic that follows the controller you last pressed a button on, plus a list of connected input sources. Useful for checking wiring and button mappings. Hold SELECT + START for 2 seconds to exit. |
+| Enter BOOTSEL Mode | Reboot into BOOTSEL so you can flash new firmware. |
+| USB Drive Mode | Show the SD card on a computer as a USB drive, so games can be added or removed without taking the card out. See [USB drive mode](#usb-drive-mode). Menu only, not available in-game. |
 | Return to emulator selection | Go back to the emulator picker. Only present in [pico-bootLoader](#running-under-pico-bootloader) builds. |
 
 > [!NOTE]
@@ -1250,6 +1252,43 @@ For games which support it, battery-backed save RAM is stored in the `/SAVES` fo
 
 > [!CAUTION]
 > The save RAM is only written back to the SD card when you quit the game properly: press **SELECT + START** to open the settings menu, then choose **Quit game**. Powering off or resetting the board while the game is running loses everything since the last save.
+
+***
+
+# USB drive mode
+
+USB drive mode presents the SD card to a computer as a USB mass storage device, so games can be added or
+removed without taking the card out of the console. Connect the console to the computer, open the
+[settings menu](#settings-menu) with SELECT from the game list and choose **USB Drive Mode**. The card
+appears on the computer as a removable drive.
+
+The entry is only offered when the settings menu is opened from the game list. It is not available while
+a game is running: the running game holds its save files open and its ROM is mapped out of flash, and
+letting the computer rewrite the card underneath that would corrupt both.
+
+When you are finished, eject the drive on the computer. The console notices this and leaves USB drive
+mode by itself. Pressing B on the console leaves as well, for when no computer is attached. The game
+list is re-read on the way out, so files added from the computer appear without having to restart.
+
+> [!NOTE]
+> Transfers are slow. The console is a USB full-speed device and reaches the card a sector at a time
+> over SPI, so copying is far slower than reading the card in a card reader. USB drive mode is meant
+> for adding or replacing a few games. For filling a card, or for copying a large amount of data, take
+> the card out and use a card reader.
+
+Behaviour depends on where controllers are connected on your board.
+
+| Board | Behaviour |
+| ----- | --------- |
+| Controllers on a separate USB port (boards built with PIO USB, such as the Fruit Jam) | The console's own USB port is free, so controllers keep working and the screen stays on. The menu returns to the game list when you are done. |
+| Controllers on the console's own USB port | That port is the one connected to the computer, so a USB controller cannot be used while the card is mounted. Press B on a controller in the NES port, or eject the drive on the computer. The console restarts afterwards. |
+| RP2040 boards | As above, and the screen is switched off for as long as the card is mounted. These boards cannot drive the video output while the computer is reading the card. The menu explains this first and lets you go back without mounting anything. |
+| SpotPear HDMI board | This board has no NES controller port, so with the USB port connected to the computer there is no button to press at all. Eject the drive on the computer to return. If no computer ever mounts the card, the console returns to the menu by itself after 20 seconds. |
+
+> [!CAUTION]
+> Eject the drive on the computer rather than pressing B. Ejecting makes the computer write out
+> anything it still had cached, and the console leaves USB drive mode on its own once it has. Pressing
+> B while the computer still has the drive open can leave files on the card incomplete.
 
 ***
 
@@ -1468,6 +1507,8 @@ Adafruit Feather DVI - RP2040 support by [PaintYourDragon](https://github.com/Pa
 XInput driver: https://github.com/Ryzee119/tusb_XInput by [Ryzee119](https://github.com/Ryzee119)
 
 FatFS driver: https://github.com/elehobica/pico_fatfs by [elehobica](https://github.com/elehobica)
+
+USB drive mode is derived from [Adafruit_ColecoJam](https://github.com/cogliano/Adafruit_ColecoJam) by [Dan Cogliano](https://github.com/cogliano)
 
 PSRAM: [AndrewCapon](https://github.com/AndrewCapon/PicoPlusPsram)
 

--- a/main.cpp
+++ b/main.cpp
@@ -108,6 +108,8 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     0,                               // YM2413 FM (SMS only, RP2350-only with HSTX)
     1,                               // Enter bootsel mode
     1,                               // Controller test
+    0,                               // Recently played (menu.cpp force-shows this in the rom browser)
+    0,                               // USB drive mode (menu.cpp force-shows this in the rom browser)
 };
 // #if defined(__riscv)
 // const uint8_t g_available_screen_modes[] = {

--- a/splash.cpp
+++ b/splash.cpp
@@ -58,6 +58,6 @@ void splash()
 
     strcpy(s, "https://github.com/");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 25, s, CLIGHTBLUE, bgcolorSplash);
-    strcpy(s, "fhoedemakers/pico-infonesPlus");
+    strcpy(s, "PicoPlus-devel/pico-infonesPlus");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 26, s, CLIGHTBLUE, bgcolorSplash);
 }


### PR DESCRIPTION
Adds a **USB drive mode** entry to the settings menu that presents the SD card to a computer as a USB mass storage device, so games can be added or removed without taking the card out. Derived from [Adafruit_ColecoJam](https://github.com/cogliano/Adafruit_ColecoJam) by Dan Cogliano.

Depends on PicoPlus-devel/pico_shared#87, already merged; the submodule pointer here is on `main`.

## Behaviour

Open the settings menu with SELECT from the game list and choose **USB Drive Mode**. The card appears on the computer as a removable drive. Ejecting it there returns the console automatically; B is there for when no computer is attached. The game list is re-read on the way out, so files copied from the computer appear without a restart.

It is offered only from the rom browser, never in-game, where save files are open and the rom is mapped out of flash.

Three board-dependent behaviours, all documented in the README:

| Board | Behaviour |
| --- | --- |
| PIO USB (Fruit Jam and friends) | Controllers keep working, screen stays on, returns to the game list. |
| Controllers on the console's own USB port | That port is the one on the computer, so USB controllers are unavailable. Press B on a NES-port controller, or eject. The console restarts afterwards. |
| RP2040 | As above, plus the screen is switched off while mounted — these boards cannot drive video while the host reads the card. The menu warns and lets the user back out first. |

The SpotPear board has no NES port, so ejecting (or a 20 s no-host timeout) is the only way back. Transfers are slow; the README says so and points at a card reader for bulk copying.

## Cost

`ENABLE_USB_MSC` is ON by default. Measured on HW_CONFIG 8 against a pristine build: **+1,848 B RAM, +14,392 B flash**, nearly all of it tinyusb's own statics. With `-DENABLE_USB_MSC=OFF`: **0 B RAM, 76 B flash** (the settings enum gained a slot).

Runtime cost is zero. The device stack is only attached while the screen is open — `tud_task()` is never called from the emulator loop, and the USB interrupt is masked on exit.

Also widens the claimable hardware spinlock pool from 8 to 12 by taking four ids off the striped range. PicoDVI builds spend four on `dvi::DVI`'s queues alone, leaving too few for the device stack. Striped locks are shared round-robin by design, so a smaller range costs contention and nothing else. This applies to the whole binary, not just USB drive mode, and was exercised with several minutes of normal gameplay on a PicoDVI RP2350 board.

## Testing

Hardware: **Fruit Jam** (PIO USB, HSTX), a **PicoDVI RP2350** board including normal gameplay, and **RP2040 HW_CONFIG 2**. Mount, file copy, eject, B-to-exit, repeated entry, and the reboot path were all exercised.

Builds clean: HW_CONFIG 1, 2, 3, 4, 8, 12, 13; the Pico W variant of 2; 2 and 13 with `-2`; and rp2350-riscv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
